### PR TITLE
simd: add missing <cstdint>

### DIFF
--- a/source/simd/md5-simd.h
+++ b/source/simd/md5-simd.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <algorithm>
 #include <stdexcept>
+#include <cstdint>
 #include <cstring>
 
 #include "simd-functions.h"


### PR DESCRIPTION
recent standard library versions do not include this header automatically, so fail with errors like:
```
In file included from md5-simd/source/simd/md5-simd.cpp:2:
md5-simd/source/simd/md5-simd.h:24:34: error: expected ‘)’ before ‘buffer_size’
   24 |                 MD5_SIMD(uint64_t buffer_size);
      |                         ~        ^~~~~~~~~~~~
      |                                  )
md5-simd/source/simd/md5-simd.h:41:47: error: ‘uint64_t’ has not been declared
   41 |                 void calculate(char* text[N], uint64_t length[N]);
      |                                               ^~~~~~~~
```